### PR TITLE
feat: PR-20 구글 OAuth 로그인 연동 및 Postman 검증 완료

### DIFF
--- a/src/main/java/org/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/backend/common/exception/GlobalExceptionHandler.java
@@ -32,4 +32,16 @@ public class GlobalExceptionHandler {
 
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<CommonResponse<?>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.warn("IllegalArgumentException: {}", ex.getMessage());
+        return new ResponseEntity<>(CommonResponse.error(ex.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(org.springframework.web.client.RestClientResponseException.class)
+    protected ResponseEntity<CommonResponse<?>> handleRestClientResponseException(org.springframework.web.client.RestClientResponseException ex) {
+        log.error("RestClientResponseException: status={}, body={}", ex.getStatusCode(), ex.getResponseBodyAsString());
+        return new ResponseEntity<>(CommonResponse.error("구글 인증 처리에 실패했습니다."), HttpStatus.BAD_REQUEST);
+    }
+
 }

--- a/src/main/java/org/backend/config/oauth/OAuthConfig.java
+++ b/src/main/java/org/backend/config/oauth/OAuthConfig.java
@@ -1,0 +1,10 @@
+package org.backend.config.oauth;
+
+import org.backend.domain.auth.oauth.props.GoogleOAuthProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(GoogleOAuthProperties.class)
+public class OAuthConfig {
+}

--- a/src/main/java/org/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/backend/domain/auth/controller/AuthController.java
@@ -1,23 +1,28 @@
-// backend-spring/src/main/java/org/backend/domain/auth/controller/AuthController.java
 package org.backend.domain.auth.controller;
 
 import jakarta.validation.Valid;
-import org.backend.domain.auth.dto.*;
+import lombok.RequiredArgsConstructor;
+import org.backend.common.CommonResponse;
+import org.backend.domain.auth.dto.request.GoogleOAuthLoginRequest;
+import org.backend.domain.auth.dto.request.LoginRequest;
+import org.backend.domain.auth.dto.request.RefreshRequest;
+import org.backend.domain.auth.dto.response.LoginResponse;
+import org.backend.domain.auth.dto.response.MeResponse;
+import org.backend.domain.auth.dto.response.TokenResponse;
 import org.backend.domain.auth.security.AdminPrincipal;
 import org.backend.domain.auth.service.AuthService;
+import org.backend.domain.auth.service.GoogleOAuthService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {
 
     private final AuthService authService;
-
-    public AuthController(AuthService authService) {
-        this.authService = authService;
-    }
+    private final GoogleOAuthService googleOAuthService;
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
@@ -52,6 +57,7 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
+
     private AdminPrincipal extractPrincipal(Authentication authentication) {
         if (authentication == null || authentication.getPrincipal() == null) {
             throw new IllegalArgumentException("인증 정보가 없습니다.");
@@ -75,4 +81,12 @@ public class AuthController {
 
         throw new IllegalArgumentException("인증 주체 정보가 올바르지 않습니다.");
     }
+
+    @PostMapping("/google")
+    public ResponseEntity<CommonResponse<LoginResponse>> googleLogin(@RequestBody @Valid GoogleOAuthLoginRequest request) {
+        LoginResponse result = googleOAuthService.loginWithCode(request.code());
+        return ResponseEntity.ok(CommonResponse.success(result, "구글 로그인 성공"));
+    }
+
+
 }

--- a/src/main/java/org/backend/domain/auth/dto/request/GoogleOAuthLoginRequest.java
+++ b/src/main/java/org/backend/domain/auth/dto/request/GoogleOAuthLoginRequest.java
@@ -1,0 +1,8 @@
+package org.backend.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record GoogleOAuthLoginRequest(
+        @NotBlank String code
+) {
+}

--- a/src/main/java/org/backend/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/org/backend/domain/auth/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package org.backend.domain.auth.dto;
+package org.backend.domain.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/org/backend/domain/auth/dto/request/RefreshRequest.java
+++ b/src/main/java/org/backend/domain/auth/dto/request/RefreshRequest.java
@@ -1,4 +1,4 @@
-package org.backend.domain.auth.dto;
+package org.backend.domain.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/src/main/java/org/backend/domain/auth/dto/response/AdminMeResponse.java
+++ b/src/main/java/org/backend/domain/auth/dto/response/AdminMeResponse.java
@@ -1,4 +1,4 @@
-package org.backend.domain.auth.dto;
+package org.backend.domain.auth.dto.response;
 
 import org.backend.domain.auth.entity.Admin;
 

--- a/src/main/java/org/backend/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/org/backend/domain/auth/dto/response/LoginResponse.java
@@ -1,4 +1,4 @@
-package org.backend.domain.auth.dto;
+package org.backend.domain.auth.dto.response;
 
 public class LoginResponse {
 

--- a/src/main/java/org/backend/domain/auth/dto/response/MeResponse.java
+++ b/src/main/java/org/backend/domain/auth/dto/response/MeResponse.java
@@ -1,4 +1,4 @@
-package org.backend.domain.auth.dto;
+package org.backend.domain.auth.dto.response;
 
 public record MeResponse(
         Long id,

--- a/src/main/java/org/backend/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/org/backend/domain/auth/dto/response/TokenResponse.java
@@ -1,4 +1,4 @@
-package org.backend.domain.auth.dto;
+package org.backend.domain.auth.dto.response;
 
 public class TokenResponse {
 

--- a/src/main/java/org/backend/domain/auth/entity/Admin.java
+++ b/src/main/java/org/backend/domain/auth/entity/Admin.java
@@ -1,7 +1,10 @@
 package org.backend.domain.auth.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -64,6 +67,18 @@ public class Admin {
         this.google = google;
         this.role = role;
         this.status = status;
+    }
+
+    public static Admin createGoogleUser(String name, String email) {
+        return Admin.builder()
+                .name(name)
+                .email(email)
+                .password(null)
+                .phone("000-0000-0000")
+                .google(true)
+                .role("ROLE_ADMIN")
+                .status("ACTIVE")
+                .build();
     }
 
     public void changePassword(String encodedPassword) {

--- a/src/main/java/org/backend/domain/auth/oauth/GoogleOAuthClient.java
+++ b/src/main/java/org/backend/domain/auth/oauth/GoogleOAuthClient.java
@@ -1,0 +1,81 @@
+package org.backend.domain.auth.oauth;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.backend.domain.auth.oauth.dto.GoogleTokenResponse;
+import org.backend.domain.auth.oauth.dto.GoogleUserInfo;
+import org.backend.domain.auth.oauth.props.GoogleOAuthProperties;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleOAuthClient {
+
+    //  기본값 fallback
+    private static final String DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+    private static final String DEFAULT_USERINFO_URI = "https://openidconnect.googleapis.com/v1/userinfo";
+
+    private final GoogleOAuthProperties props;
+
+    private final RestClient restClient = RestClient.builder().build();
+
+    // 앱 기동 시점에 설정값 검증 → 빈 값이면 바로 에러로 알려줌
+    @PostConstruct
+    void validateProps() {
+        // clientId / clientSecret / redirectUri 는 "필수"
+        requireText(props.clientId(), "app.google.client-id (GOOGLE_CLIENT_ID)");
+        requireText(props.clientSecret(), "app.google.client-secret (GOOGLE_CLIENT_SECRET)");
+        requireText(props.redirectUri(), "app.google.redirect-uri (GOOGLE_REDIRECT_URI)");
+
+        // tokenUri / userInfoUri 는 "없으면 fallback" 하되, 경고 성격으로 예외 대신 통과
+        // (원하면 여기서도 requireText로 강제해도 됨)
+    }
+
+    public GoogleUserInfo getUserInfoByCode(String code) {
+        GoogleTokenResponse token = exchangeToken(code);
+        return fetchUserInfo(token.accessToken());
+    }
+
+    private GoogleTokenResponse exchangeToken(String code) {
+        String tokenUri = firstNonBlank(props.tokenUri(), DEFAULT_TOKEN_URI);
+
+        return restClient.post()
+                .uri(tokenUri) // props가 비어도 기본 URL로 보정
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body("code=" + encode(code)
+                        + "&client_id=" + encode(props.clientId())
+                        + "&client_secret=" + encode(props.clientSecret())
+                        + "&redirect_uri=" + encode(props.redirectUri())
+                        + "&grant_type=authorization_code")
+                .retrieve()
+                .body(GoogleTokenResponse.class);
+    }
+
+    private GoogleUserInfo fetchUserInfo(String accessToken) {
+        String userInfoUri = firstNonBlank(props.userInfoUri(), DEFAULT_USERINFO_URI);
+
+        return restClient.get()
+                .uri(userInfoUri) // props가 비어도 기본 URL로 보정
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .body(GoogleUserInfo.class);
+    }
+
+    private String encode(String v) {
+        return java.net.URLEncoder.encode(v, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    //  유틸 메서드들
+    private String firstNonBlank(String value, String fallback) {
+        return StringUtils.hasText(value) ? value : fallback;
+    }
+
+    private void requireText(String value, String keyName) {
+        if (!StringUtils.hasText(value)) {
+            throw new IllegalStateException("Google OAuth 설정 누락/빈 값: " + keyName);
+        }
+    }
+}

--- a/src/main/java/org/backend/domain/auth/oauth/dto/GoogleTokenResponse.java
+++ b/src/main/java/org/backend/domain/auth/oauth/dto/GoogleTokenResponse.java
@@ -1,0 +1,13 @@
+package org.backend.domain.auth.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("expires_in") Integer expiresIn,
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("scope") String scope,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("id_token") String idToken
+) {
+}

--- a/src/main/java/org/backend/domain/auth/oauth/dto/GoogleUserInfo.java
+++ b/src/main/java/org/backend/domain/auth/oauth/dto/GoogleUserInfo.java
@@ -1,0 +1,15 @@
+package org.backend.domain.auth.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleUserInfo(
+        String id,
+        String email,
+        @JsonProperty("verified_email") Boolean verifiedEmail,
+        String name,
+        @JsonProperty("given_name") String givenName,
+        @JsonProperty("family_name") String familyName,
+        String picture,
+        String locale
+) {
+}

--- a/src/main/java/org/backend/domain/auth/oauth/props/GoogleOAuthProperties.java
+++ b/src/main/java/org/backend/domain/auth/oauth/props/GoogleOAuthProperties.java
@@ -1,0 +1,13 @@
+package org.backend.domain.auth.oauth.props;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.google")
+public record GoogleOAuthProperties(
+        String clientId,
+        String clientSecret,
+        String redirectUri,
+        String tokenUri,
+        String userInfoUri
+) {
+}

--- a/src/main/java/org/backend/domain/auth/repository/AuthWhitelistEmailRepository.java
+++ b/src/main/java/org/backend/domain/auth/repository/AuthWhitelistEmailRepository.java
@@ -1,0 +1,8 @@
+package org.backend.domain.auth.repository;
+
+import org.backend.domain.auth.entity.AuthWhitelistEmail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthWhitelistEmailRepository extends JpaRepository<AuthWhitelistEmail, Long> {
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/org/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/org/backend/domain/auth/service/AuthService.java
@@ -2,7 +2,11 @@ package org.backend.domain.auth.service;
 
 import io.jsonwebtoken.Claims;
 import org.backend.config.security.JwtProvider;
-import org.backend.domain.auth.dto.*;
+import org.backend.domain.auth.dto.request.LoginRequest;
+import org.backend.domain.auth.dto.request.RefreshRequest;
+import org.backend.domain.auth.dto.response.LoginResponse;
+import org.backend.domain.auth.dto.response.MeResponse;
+import org.backend.domain.auth.dto.response.TokenResponse;
 import org.backend.domain.auth.entity.Admin;
 import org.backend.domain.auth.entity.RefreshToken;
 import org.backend.domain.auth.repository.AdminRepository;

--- a/src/main/java/org/backend/domain/auth/service/GoogleOAuthService.java
+++ b/src/main/java/org/backend/domain/auth/service/GoogleOAuthService.java
@@ -1,0 +1,50 @@
+package org.backend.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.backend.config.security.JwtProvider;
+import org.backend.domain.auth.dto.response.LoginResponse;
+import org.backend.domain.auth.entity.Admin;
+import org.backend.domain.auth.entity.RefreshToken;
+import org.backend.domain.auth.oauth.GoogleOAuthClient;
+import org.backend.domain.auth.oauth.dto.GoogleUserInfo;
+import org.backend.domain.auth.repository.AdminRepository;
+import org.backend.domain.auth.repository.RefreshTokenRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleOAuthService {
+
+    private final GoogleOAuthClient googleOAuthClient;
+    private final WhitelistService whitelistService;
+
+    private final AdminRepository adminRepository;
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public LoginResponse loginWithCode(String code) {
+        GoogleUserInfo userInfo = googleOAuthClient.getUserInfoByCode(code);
+
+        whitelistService.validate(userInfo.email());
+
+        Admin admin = adminRepository.findByEmail(userInfo.email())
+                .orElseGet(() -> adminRepository.save(Admin.createGoogleUser(userInfo.name(), userInfo.email())));
+
+        String accessToken = jwtProvider.generateAccessToken(admin.getId(), admin.getEmail(), admin.getRole());
+        String refreshToken = jwtProvider.generateRefreshToken(admin.getId());
+
+        upsertRefreshToken(admin.getId(), refreshToken);
+
+        return new LoginResponse(accessToken, refreshToken, admin.getId(), admin.getEmail(), admin.getRole());
+    }
+
+    private void upsertRefreshToken(Long adminId, String token) {
+        RefreshToken rt = refreshTokenRepository.findByAdminId(adminId)
+                .orElseGet(() -> RefreshToken.builder().adminId(adminId).build());
+
+        rt.updateToken(token);
+        refreshTokenRepository.save(rt);
+    }
+}

--- a/src/main/java/org/backend/domain/auth/service/WhitelistService.java
+++ b/src/main/java/org/backend/domain/auth/service/WhitelistService.java
@@ -1,0 +1,31 @@
+package org.backend.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.backend.domain.auth.repository.AuthWhitelistEmailRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WhitelistService {
+
+    private final AuthWhitelistEmailRepository whitelistEmailRepository;
+
+    // 옵션: 도메인 제한을 같이 걸고 싶으면 사용 (비어있으면 도메인 체크 스킵)
+    @Value("${auth.whitelist.domain:}")
+    private String allowedDomain;
+
+    public void validate(String email) {
+        // 1) 도메인 제한(옵션)
+        if (allowedDomain != null && !allowedDomain.isBlank()) {
+            if (!email.toLowerCase().endsWith("@" + allowedDomain.toLowerCase())) {
+                throw new IllegalArgumentException("허용되지 않은 이메일 도메인입니다.");
+            }
+        }
+
+        // 2) 화이트리스트 테이블 체크
+        if (!whitelistEmailRepository.existsByEmail(email)) {
+            throw new IllegalArgumentException("화이트리스트에 등록되지 않은 이메일입니다.");
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,5 +17,10 @@ app.jwt.secret=${APP_JWT_SECRET}
 app.google.client-id=${GOOGLE_CLIENT_ID}
 app.google.client-secret=${GOOGLE_CLIENT_SECRET}
 app.google.redirect-uri=${GOOGLE_REDIRECT_URI}
+app.google.token-uri=https://oauth2.googleapis.com/token
+app.google.userinfo-uri=https://openidconnect.googleapis.com/v1/userinfo
+
 
 logging.level.org.springframework.security=DEBUG
+server.error.include-message=always
+server.error.include-binding-errors=always


### PR DESCRIPTION
## #️⃣ 작업 내용

1. 구글 OAuth 로그인(code → token → userinfo) 연동 구현
- 프론트 Redirect URI(http://localhost:3000/oauth/google/callback)로 전달되는 authorization code를 백엔드수신
- Google Token Endpoint로 Access Token 교환
- Google UserInfo Endpoint로 사용자 정보(email, name 등) 조회
2. 화이트리스트 기반 접근 제어 적용
- auth_whitelist_emails 테이블에 등록된 이메일만 로그인 허용
3. Admin 계정 자동 생성/연동 처리
- 최초 로그인(화이트리스트 통과) 시 admin 데이터 생성(google=true, role=ROLE_ADMIN 등 정책에 맞게)
- 기존 계정 존재 시 조회 후 로그인 처리
4. JWT 발급 플로우 연결
- AccessToken / RefreshToken 발급 및 응답 포맷 정리(기존 로그인 플로우와 동일하게)
5. Dto 요청/응답 구조 세분화
- dto/requset , dto/response 폴더구조 세분화

## #️⃣ 테스트 결과

기본적으로 아래의 5개의 insert문 작동후에 진행하시면됩니다.
```
INSERT INTO admin (name, email, phone, google, role, status, password, created_at, updated_at)
VALUES ('관리자', 'admin@test.com', '010-1111-2222', false, 'ROLE_ADMIN', 'ACTIVE',
'$2a$10$sIEXhq8EvlnFecZeaMtEs.lGKnuN9wP5WVlm6c0mNo0WDMCDF02Fi',
NOW(), NOW());

INSERT INTO product (price, product_category, product_name, product_type)
VALUES (55000, 'MOBILE', 'OJO 기본요금제', 'POSTPAID');



INSERT INTO member
(address, birth_date, created_at, email, gender, household_type, name, phone, region, status)
VALUES
('서울특별시 강남구', '1999-01-01', NOW(), 'member1@test.com', 'M', 1, '홍길동', '010-9999-8888', '서울', 'ACTIVE');



INSERT INTO subscription_period (end_at, quantity, reason_code, started_at, status, total_price, member_id, product_id)
VALUES (
  DATE_ADD(NOW(), INTERVAL 30 DAY),  -- end_at
  1,                                 -- quantity
  NULL,                              -- reason_code
  NOW(),                             -- started_at
  'ACTIVE',                          -- status
  55000,                             -- total_price
  1,                                 -- member_id (너가 만든 멤버)
  (SELECT product_id FROM product ORDER BY product_id DESC LIMIT 1) -- 최신 product
);


INSERT INTO auth_whitelist_emails(email, created_at)
VALUES ('본인 구글 이메일', NOW());

```

```
INSERT INTO auth_whitelist_emails(email, created_at)
VALUES ('본인 구글 이메일', NOW());

```
이부분에는 본인 이메일 데이터 입력해야합니다

```
https://accounts.google.com/o/oauth2/v2/auth?client_id=675857516469-jvfrgq3atp4la7u8k490i2ovbkr6pglk.apps.googleusercontent.com&redirect_uri=http://localhost:3000/oauth/google/callback&response_type=code&scope=openid%20email%20profile&access_type=offline&prompt=consent
```
제가 미리 만든 클라이언트가 존재하여 
노션 https://www.notion.so/env-30e7e98d8fc680d19dd1c2f699d19b51 이곳에 .env파일의 클라이언트 아이디로
요청 보낼시 아래의 사진처럼 나올겁니다.
<img width="2416" height="1487" alt="image" src="https://github.com/user-attachments/assets/6bedc3d3-9e21-41ec-b266-15be27fe74c3" />
이곳에서 각자의 계정 선택하시면 
<img width="2341" height="1541" alt="image" src="https://github.com/user-attachments/assets/fb4a5f9f-3827-4529-8656-47b570a0b106" />
위의 사진의 밑줄부분에 code가 나옵니다 이곳의 코드를 복사해서 
<img width="1940" height="388" alt="image" src="https://github.com/user-attachments/assets/37cc905b-062e-4b9d-a68e-a8dee478b8f6" />
<img width="1931" height="1379" alt="image" src="https://github.com/user-attachments/assets/bb5b7185-401d-4898-b0cb-92fa75e69ca4" />
이렇게 설정후 send할시 위의 결과처럼 테스트 성공하시면됩니다.

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)



## #️⃣ 리뷰 요구사항 (선택)

예외 처리 흐름이 적절한지 확인 부탁드립니다.

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요
